### PR TITLE
Refactors afterResponse dispatch mechanism

### DIFF
--- a/src/Subscribers/EventSubscriber.php
+++ b/src/Subscribers/EventSubscriber.php
@@ -26,7 +26,7 @@ class EventSubscriber
         foreach (config('event-emitter.eloquents', []) as $eloquent => $eloquentEvents) {
             foreach ($eloquentEvents as $event => $config) {
                 $qualifiedEventName = "eloquent.{$event}: {$eloquent}";
-                $events->listen($qualifiedEventName, function ($model) use ($qualifiedEventName, $config) {
+                $events->listen($qualifiedEventName, function ($model) use ($qualifiedEventName, $config, $events) {
                     # If we should not handle the listener, return immediately
                     # This flag will be turned on to prevent echoing
                     if (static::$shouldSkipHandling) {
@@ -59,7 +59,7 @@ class EventSubscriber
                         };
                         
                         if (data_get($options, 'afterResponse', false)) {
-                            app()->terminating($dispatch);
+                            $events->listen('Illuminate\Foundation\Http\Events\RequestHandle', $dispatch);
                         } else {
                             $dispatch();
                         }

--- a/src/Subscribers/EventSubscriber.php
+++ b/src/Subscribers/EventSubscriber.php
@@ -59,7 +59,7 @@ class EventSubscriber
                         };
                         
                         if (data_get($options, 'afterResponse', false)) {
-                            $events->listen('Illuminate\Foundation\Http\Events\RequestHandle', $dispatch);
+                            $events->listen('Illuminate\Foundation\Http\Events\RequestHandled', $dispatch);
                         } else {
                             $dispatch();
                         }


### PR DESCRIPTION
Updates the afterResponse dispatch mechanism to use a request handling event instead of the terminating callback.

This change ensures that the dispatch logic is executed within the request lifecycle, providing a more reliable and predictable execution context.